### PR TITLE
🐛 fix the timer triggering the git index job

### DIFF
--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -268,7 +268,7 @@ in
               WantedBy = [ "timers.target" ];
             };
             Timer = {
-              OnUnitActiveSec = cfg.services.index-git-repositories.interval;
+              OnUnitInactiveSec = cfg.services.index-git-repositories.interval;
               OnBootSec = "0min";
               Persistent = true;
               Unit = "${git-index-name}-service.service";


### PR DESCRIPTION
# Problem
The systemd timer for the git index service was configuered to run `OnUnitActiveSec`. This requires the service which is triggered to be active at some point to repeat the timer. Since the `index-git-repositories-service` is a `Oneshot` service, it will never enter the active state. Instead it will transition thorugh the following states when triggered: `inactive` -> `activating` (executing the `ExecStart` command) -> `inactive`. This resulted in the timer only being executed once per boot since it has `OnBootSec` configured.

# Solution
This PR switches the timer from using `OnUnitActiveSec` to `OnUnitInactiveSec` which works for `Oneshot` services.